### PR TITLE
IBINT-184: Añadir el método NotificacioEsdeveniment en el servicio de Notificacions

### DIFF
--- a/src/WiFIS/V202/BS/Notificacions/NotificacionsSoap.cls
+++ b/src/WiFIS/V202/BS/Notificacions/NotificacionsSoap.cls
@@ -32,6 +32,11 @@ Method NotificacioAlerta(any As %XML.GlobalCharacterStream(XMLPROJECTION="any"))
  quit ..Forward(any,"Notificacions",$$$CurrentMethod)
 }
 
+Method NotificacioEsdeveniment(any As %XML.GlobalCharacterStream(XMLPROJECTION="any")) As WiFIS.V202.BS.s1.WSResposta(XMLNAME="NotificacioEsdevenimentResponseResult") [ Final, ProcedureBlock = 1, SoapAction = "http://pdm.isalut.gencat.net/Notificacions/NotificacioEsdeveniment", SoapBindingStyle = document, SoapBodyUse = literal, WebMethod ]
+{
+ quit ..Forward(any,"Notificacions",$$$CurrentMethod)
+}
+
 Method NotificacioRealitzacio(any As %XML.GlobalCharacterStream(XMLPROJECTION="any")) As WiFIS.V202.BS.s1.WSResposta(XMLNAME="NotificacioRealitzacioResponseResult") [ Final, ProcedureBlock = 1, SoapAction = "http://pdm.isalut.gencat.net/Notificacions/NotificacioRealitzacio", SoapBindingStyle = document, SoapBodyUse = literal, WebMethod ]
 {
  quit ..Forward(any,"Notificacions",$$$CurrentMethod)

--- a/src/WiFIS/V202/WSC/Notificacions/NotificacionsSoap.cls
+++ b/src/WiFIS/V202/WSC/Notificacions/NotificacionsSoap.cls
@@ -11,6 +11,11 @@ Method NotificacioAlerta(any As %XML.GlobalCharacterStream(XMLPROJECTION="any"))
  Quit ..WebMethod("NotificacioAlerta").Invoke($this,"http://pdm.isalut.gencat.net/Notificacions/NotificacioAlerta",.any)
 }
 
+Method NotificacioEsdeveniment(any As %XML.GlobalCharacterStream(XMLPROJECTION="any")) As WiFIS.V202.WSC.s1.WSResposta(XMLNAME="NotificacioEsdevenimentResponseResult") [ Final, ProcedureBlock = 1, SoapBindingStyle = document, SoapBodyUse = literal, WebMethod ]
+{
+ Quit ..WebMethod("NotificacioEsdeveniment").Invoke($this,"http://pdm.isalut.gencat.net/Notificacions/NotificacioEsdeveniment",.any)
+}
+
 Method NotificacioRealitzacio(any As %XML.GlobalCharacterStream(XMLPROJECTION="any")) As WiFIS.V202.WSC.s1.WSResposta(XMLNAME="NotificacioRealitzacioResponseResult") [ Final, ProcedureBlock = 1, SoapBindingStyle = document, SoapBodyUse = literal, WebMethod ]
 {
  Quit ..WebMethod("NotificacioRealitzacio").Invoke($this,"http://pdm.isalut.gencat.net/Notificacions/NotificacioRealitzacio",.any)


### PR DESCRIPTION
Añadir a wifis-connect estándar un nuevo método del servicio de Notificacions. Este método viene definido por IS3 y en algunos clientes ya lo están usando (lo han añadido ellos a sus clases).